### PR TITLE
Add 2 tests for isMd() and configExist() handling errors correctly

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -58,11 +58,17 @@ describe("\nSSG Testing", function () {
   test("Test: isMd() == false", function () {
     expect(isMd("testFiles/notafile.txt")).toBeFalsy();
   });
+  test("Test: isMd() throws error and returns false", function () {
+    expect(isMd(12546)).toBeFalsy();
+  });
   test("Test: configExist() == true", function () {
     expect(configExist("testFiles/ssg-config.json")).toBeTruthy();
   });
   test("Test: configExist() == false", function () {
     expect(configExist("testFiles/notafile.txt")).toBeFalsy();
+  });
+  test("Test: configExist() throws error and returns false", function () {
+    expect(configExist(11234)).toBeFalsy();
   });
   test("Test: getLang() with no arguments", function () {
     expect(getLang()).toBe("en-CA");


### PR DESCRIPTION
## Description

I ran the coverage result and found out line 24 and 32 of `utils.js` isn't covered, so I added 2 tests to cover the cases where an error is thrown for the code to handle, to cover these lines.

## Changes
Added 2 tests in `test.js` at line 61-63 and line 70-72.